### PR TITLE
Refine WeFlow futuristic UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,22 @@
 import streamlit as st
+import os
+import json
+import requests
 
 # Configuration de la page
 st.set_page_config(page_title="WeFlow", layout="centered", initial_sidebar_state="collapsed")
+
+WEBHOOK_URL = os.getenv("WEBHOOK_URL")
+
+def call_webhook(text: str, mode: str):
+    """Send the text and mode to the configured webhook."""
+    if not WEBHOOK_URL:
+        return {"mode": mode, "text": text}
+    try:
+        response = requests.post(WEBHOOK_URL, json={"text": text, "mode": mode}, timeout=5)
+        return response.json()
+    except Exception as exc:
+        return {"error": str(exc), "mode": mode, "text": text}
 
 # Masquer le menu, le footer et l’en-tête Streamlit par défaut
 hide_streamlit_style = """
@@ -21,7 +36,7 @@ body {
     transform: translate(-50%, -50%);
     font-size: 6rem;
     font-weight: 600;
-    color: rgba(0, 0, 0, 0.05);
+    color: rgba(0, 0, 0, 0.03);
     pointer-events: none;
     user-select: none;
     text-transform: uppercase;
@@ -33,7 +48,7 @@ body {
 }
 .brand {
     font-size: 4rem;
-    letter-spacing: 0.1rem;
+    letter-spacing: 0.3rem;
     margin: 0;
 }
 .plans {
@@ -52,9 +67,11 @@ body {
     height: 80px !important;
     margin-top: 2rem;
     font-size: 1rem;
-    border: none;
+    background: rgba(255, 255, 255, 0.6);
+    border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 8px;
     box-shadow: 0 2px 10px rgba(0, 128, 255, 0.15);
+    backdrop-filter: blur(6px);
     padding: 1rem;
     resize: none;
     outline: none;
@@ -67,24 +84,28 @@ body {
 }
 .option-button {
     padding: 0.5rem 1rem;
-    background-color: transparent;
-    border: 1px solid rgba(0, 0, 0, 0.2);
+    background-color: rgba(255, 255, 255, 0.3);
+    border: 1px solid rgba(0, 128, 255, 0.3);
     border-radius: 4px;
     font-size: 0.8rem;
     letter-spacing: 0.1rem;
     cursor: pointer;
+    backdrop-filter: blur(4px);
     transition: background-color 0.2s, color 0.2s;
     text-transform: uppercase;
 }
 .option-button.selected {
-    background-color: rgba(0, 128, 255, 0.1);
+    background-color: rgba(0, 128, 255, 0.15);
     color: #0050b3;
 }
 .card {
-    background-color: rgba(0, 128, 255, 0.05);
+    background-color: rgba(255, 255, 255, 0.6);
+    border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 8px;
     padding: 1rem;
     margin-top: 1rem;
+    box-shadow: 0 2px 8px rgba(0, 128, 255, 0.1);
+    backdrop-filter: blur(6px);
 }
 </style>
 """
@@ -117,7 +138,8 @@ user_text = st.text_area("", placeholder="Entrez du texte ici...", key="input_zo
 
 # Affichage des cartes de résultat
 if user_text:
-    st.markdown(f'<div class="card">Mode : {display_mode}</div>', unsafe_allow_html=True)
-    st.markdown(f'<div class="card">Texte reçu : {user_text}</div>', unsafe_allow_html=True)
+    result = call_webhook(user_text, display_mode)
+    pretty = json.dumps(result, ensure_ascii=False, indent=2)
+    st.markdown(f'<div class="card"><pre>{pretty}</pre></div>', unsafe_allow_html=True)
 
 st.markdown('</div>', unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- add webhook helpers and placeholders
- tweak watermark color and brand spacing
- apply frosted-glass style to text input and buttons
- return webhook data as translucent cards

## Testing
- `pip install -r requirements.txt`
- `streamlit run app.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_b_6870e30e03e08322a3239e990f7ee665